### PR TITLE
ICU and Intl Version Checks

### DIFF
--- a/src.php
+++ b/src.php
@@ -3,6 +3,7 @@ require_once __DIR__ . '/src/Aura/Intl/Exception.php';
 require_once __DIR__ . '/src/Aura/Intl/Exception/CannotFormat.php';
 require_once __DIR__ . '/src/Aura/Intl/Exception/CannotInstantiateFormatter.php';
 require_once __DIR__ . '/src/Aura/Intl/Exception/FormatterNotMapped.php';
+require_once __DIR__ . '/src/Aura/Intl/Exception/IcuVersionTooLow.php';
 require_once __DIR__ . '/src/Aura/Intl/Exception.php';
 require_once __DIR__ . '/src/Aura/Intl/FormatterInterface.php';
 require_once __DIR__ . '/src/Aura/Intl/FormatterLocator.php';

--- a/src/Aura/Intl/Exception/IcuVersionTooLow.php
+++ b/src/Aura/Intl/Exception/IcuVersionTooLow.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * 
+ * This file is part of the Aura Project for PHP.
+ * 
+ * @package Aura.Intl
+ * 
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ * 
+ */
+namespace Aura\Intl\Exception;
+
+use Aura\Intl\Exception;
+
+/**
+ * 
+ * ICU Version is too low for Aura.Intl to work properly.
+ * 
+ * @package Aura.Intl
+ * 
+ */
+class IcuVersionTooLow extends \Exception
+{
+}

--- a/src/Aura/Intl/IntlFormatter.php
+++ b/src/Aura/Intl/IntlFormatter.php
@@ -22,6 +22,20 @@ use MessageFormatter;
 class IntlFormatter implements FormatterInterface
 {
     /**
+     * Constructor for IntlFormatter
+     *
+     * Throws IcuVersionTooLow Exception when the Version of ICU installed is too low for Aura.Intl to work properly.
+     *
+     * @throws Exception
+     */
+    public function __construct()
+    {
+        if (version_compare(INTL_ICU_VERSION, '4.8') < 0) {
+            throw new Exception\IcuVersionTooLow('ICU Version 4.8 or higher required.');
+        }
+    }
+
+    /**
      * 
      * Format the message with the help of php intl extension
      * 

--- a/tests/Aura/Intl/IntlFormatterTest.php
+++ b/tests/Aura/Intl/IntlFormatterTest.php
@@ -7,6 +7,13 @@ class IntlFormatterTest extends BasicFormatterTest
     {
         return new IntlFormatter;
     }
+
+    public function setUp()
+    {
+        if (! extension_loaded('intl')) {
+            $this->markTestSkipped('This test is skipped if the Intl Extension is not loaded.');
+        }
+    }
     
     /**
      * This test fails on PHP 5.4.4
@@ -50,11 +57,6 @@ class IntlFormatterTest extends BasicFormatterTest
      */
     public function testFormat_select($tokens_values, $expect)
     {
-        // https://github.com/php/php-src/blob/master/ext/intl/tests/msgfmt_format_subpatterns.phpt
-        if (version_compare(INTL_ICU_VERSION, '4.8') < 0) {
-            $this->markTestSkipped('Skip for ICU 4.8+');
-        }
-        
         $locale = 'en_US';
         $string = "
             {gender, select,


### PR DESCRIPTION
Making ICU Version 4.8+ a requirement for using IntlFormatter.
If ICU < 4.8 a IcuVersionTooLow Exception is thrown on instantiating IntlFormatter.

Skip tests if the intl extension is not loaded.
