### PR TITLE
Formatting the translation key whenever arguments are passed.

### DIFF
--- a/src/Aura/Intl/Translator.php
+++ b/src/Aura/Intl/Translator.php
@@ -129,7 +129,7 @@ class Translator implements TranslatorInterface
         // do we have a message string?
         if (! $message) {
             // no, return the message key as-is
-            return $key;
+            $message = $key;
         }
 
         // are there token replacement values?

--- a/tests/Aura/Intl/TranslatorTest.php
+++ b/tests/Aura/Intl/TranslatorTest.php
@@ -70,4 +70,22 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $actual = $translator->translate('TEXT_NONE');
         $this->assertSame($expect, $actual);
     }
+
+    public function testTranslateMissingKey()
+    {
+        $formatter = $this->getMock(get_class($this->formatter));
+        // create fallback translator
+        $translator = new Translator('en_US', [], $formatter);
+
+        $formatter
+            ->method('format')
+            ->with('en_US', 'TEXT', ['var' => 'SOME'])
+            ->will($this->returnValue('FORMATTED'));
+
+        // key does not exist, with tokens passed
+        $expect = 'FORMATTED';
+        $actual = $translator->translate('TEXT', ['var' => 'SOME']);
+        $this->assertEquals($expect, $actual);
+	}
+
 }


### PR DESCRIPTION
In some applications it is easier to use the `key` as a human readable string,
which can contain formatting placeholders. With this feature the developer
will be able to see immediate feedback of their translation messages without
having to translate messages to a specific locale beforehand.
