### PR TITLE
Get rid of installer default 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "aura/intl",
-    "type": "aura-package",
+    "type": "library",
     "description": "The Aura Intl package provides internationalization tools, specifically message translation.",
     "keywords": ["intl", "internationalization", "i18n", "l10n", "localization", "globalization", "g11n"],
     "homepage": "http://auraphp.github.com/Aura.Intl",
@@ -12,8 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "aura/installer-default": "1.0.0"
+        "php": ">=5.4.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I noticed a message in cakephp irc channel, 

<waspinator> I'm trying to install cake on ubuntu using composer and I get this runtime error. any ideas? Plugin aura/installer-default is missing a require statement for a version of the composer-plugin-api package.
<waspinator> the command I'm using for the install is composer create-project --prefer-dist cakephp/app [app_name]
<harikt> waspinator, could you open an issue at https://github.com/auraphp/Aura.Intl/ ?
<waspinator> sure
<harikt> waspinator, also you could do a -vvv to tell composer to display more errors

May be we need v2 or I am also ok with the change for 1.x framework is no longer maintained .

Also when I testing the same command, I have not experienced the issue.
