### PR TITLE
Making Translator's messages 'mutable'

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -109,7 +109,7 @@ class Package
      */
     public function addMessages($messages)
     {
-        array_merge($this->messages, $messages);
+        $this->messages = array_merge($this->messages, $messages);
     }
 
     /**

--- a/src/Package.php
+++ b/src/Package.php
@@ -84,6 +84,50 @@ class Package
 
     /**
      *
+     * Adds one message for this package.
+     *
+     * @param string $key the key of the message
+     *
+     * @param string $message the actual message
+     *
+     * @return void
+     *
+     */
+    public function addMessage($key, $message)
+    {
+        $this->messages[$key] = $message;
+    }
+
+    /**
+     *
+     * Adds new messages for this package.
+     *
+     * @param array $messages The messages to add in this package.
+     *
+     * @return void
+     *
+     */
+    public function addMessages($messages)
+    {
+        array_merge($this->messages, $messages);
+    }
+
+    /**
+     *
+     * Removes one message for this package.
+     *
+     * @param string $key the key of the message to remove
+     *
+     * @return void
+     *
+     */
+    public function removeMessage($key)
+    {
+        unset($this->messages[$key]);
+    }
+
+    /**
+     *
      * Gets the messages for this package.
      *
      * @return array
@@ -92,6 +136,23 @@ class Package
     public function getMessages()
     {
         return $this->messages;
+    }
+
+
+    /**
+     *
+     * Gets the message of the given key for this package.
+     *
+     * @param string $key the key of the message to return
+     *
+     * @return string|null
+     *
+     */
+    public function getMessage($key)
+    {
+        if (isset($this->messages[$key])) {
+            return $this->messages[$key];
+        }
     }
 
     /**

--- a/src/Package.php
+++ b/src/Package.php
@@ -131,7 +131,7 @@ class Package
      *
      * @param string $key the key of the message to return
      *
-     * @return string|null
+     * @return mixed The message translation string, or false if not found.
      *
      */
     public function getMessage($key)
@@ -139,6 +139,8 @@ class Package
         if (isset($this->messages[$key])) {
             return $this->messages[$key];
         }
+
+        return false;
     }
 
     /**

--- a/src/Package.php
+++ b/src/Package.php
@@ -114,20 +114,6 @@ class Package
 
     /**
      *
-     * Removes one message for this package.
-     *
-     * @param string $key the key of the message to remove
-     *
-     * @return void
-     *
-     */
-    public function removeMessage($key)
-    {
-        unset($this->messages[$key]);
-    }
-
-    /**
-     *
      * Gets the messages for this package.
      *
      * @return array

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -90,7 +90,8 @@ class Translator implements TranslatorInterface
      */
     protected function getMessage($key)
     {
-        if ($message = ($this->package->getMessage($key))) {
+        $message = $this->package->getMessage($key);
+        if ($message) {
             return $message;
         }
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -142,4 +142,14 @@ class Translator implements TranslatorInterface
         // run message string through formatter to replace tokens with values
         return $this->formatter->format($this->locale, $message, $tokens_values);
     }
+
+    /**
+     *
+     * @return Package
+     *
+     */
+    public function getPackage()
+    {
+        return $this->package;
+    }
 }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -47,13 +47,12 @@ class Translator implements TranslatorInterface
     protected $locale;
 
     /**
+     * The Package containing keys and translations.
      *
-     * The message keys and translations.
-     *
-     * @var array
+     * @var Package
      *
      */
-    protected $messages = [];
+    protected $package;
 
     /**
      *
@@ -61,7 +60,7 @@ class Translator implements TranslatorInterface
      *
      * @param string $locale The locale being used.
      *
-     * @param array $messages The message keys and translations.
+     * @param Package $package The Package containing keys and translations.
      *
      * @param FormatterInterface $formatter A message formatter.
      *
@@ -70,12 +69,12 @@ class Translator implements TranslatorInterface
      */
     public function __construct(
         $locale,
-        array $messages,
+        Package $package,
         FormatterInterface $formatter,
         TranslatorInterface $fallback = null
     ) {
         $this->locale    = $locale;
-        $this->messages  = $messages;
+        $this->package   = $package;
         $this->formatter = $formatter;
         $this->fallback  = $fallback;
     }
@@ -91,17 +90,19 @@ class Translator implements TranslatorInterface
      */
     protected function getMessage($key)
     {
-        if (isset($this->messages[$key])) {
-            return $this->messages[$key];
+        if ($message = ($this->package->getMessage($key))) {
+            return $message;
         }
 
         if ($this->fallback) {
             // get the message from the fallback translator
             $message = $this->fallback->getMessage($key);
-            // speed optimization: retain locally
-            $this->messages[$key] = $message;
-            // done!
-            return $message;
+            if ($message) {
+                // speed optimization: retain locally
+                $this->package->addMessage($key, $message);
+                // done!
+                return $message;
+            }
         }
 
         // no local message, no fallback

--- a/src/TranslatorFactory.php
+++ b/src/TranslatorFactory.php
@@ -34,7 +34,7 @@ class TranslatorFactory
      *
      * @param string $locale The locale code for the translator.
      *
-     * @param array $messages The localized messages for the translator.
+     * @param Package $package The localized package for the translator.
      *
      * @param FormatterInterface $formatter The formatter to use for
      * interpolating token values.
@@ -47,11 +47,11 @@ class TranslatorFactory
      */
     public function newInstance(
         $locale,
-        array $messages,
+        Package $package,
         FormatterInterface $formatter,
         TranslatorInterface $fallback = null
     ) {
         $class = $this->class;
-        return new $class($locale, $messages, $formatter, $fallback);
+        return new $class($locale, $package, $formatter, $fallback);
     }
 }

--- a/src/TranslatorLocator.php
+++ b/src/TranslatorLocator.php
@@ -15,7 +15,7 @@ namespace Aura\Intl;
  * A ServiceLocator implementation for loading and retaining translator objects.
  *
  * @package Aura.Intl
- * 
+ *
  */
 class TranslatorLocator
 {
@@ -183,7 +183,7 @@ class TranslatorLocator
             // 'fallback' param at the very end.
             $translator = $this->factory->newInstance(
                 $locale,
-                $package->getMessages(),
+                $package,
                 $this->formatters->get($package->getFormatter()),
                 $this->get($package->getFallback(), $locale)
             );

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -7,6 +7,8 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     protected $factory;
 
+    protected $package;
+
     protected $locale = 'en_US';
 
     protected $messages = [
@@ -20,7 +22,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     {
         return $this->factory->newInstance(
             'en_US',
-            $this->messages,
+            $this->package,
             $this->formatter,
             $fallback
         );
@@ -30,6 +32,8 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->factory = new TranslatorFactory;
         $this->formatter = new MockFormatter;
+        $this->package = new Package;
+        $this->package->setMessages($this->messages);
         $this->translator = $this->newTranslator();
     }
 
@@ -53,12 +57,14 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslate_fallback()
     {
+        $package = new Package;
+        $package->setMessages([
+            'TEXT_NONE' => 'Fallback text',
+        ]);
         // create fallback translator
         $fallback = new Translator(
             'en_US',
-            [
-                'TEXT_NONE' => 'Fallback text',
-            ],
+            $package,
             $this->formatter
         );
 
@@ -75,7 +81,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = $this->getMock(get_class($this->formatter));
         // create fallback translator
-        $translator = new Translator('en_US', [], $formatter);
+        $translator = new Translator('en_US', new Package, $formatter);
 
         $formatter->expects($this->once())
             ->method('format')


### PR DESCRIPTION
Alright, this PR is more a proposal than anything else.

In my application i happen to only load translations "template" by template, thus i have a translation file by template. This means that i dynamically load translations at runtime depending on which template i need at that time.

Because of the way Aura.Intl is made, there is no way to change the messages once a Translator has been created, disallowing one to load more translation messages at runtime.

In order to fix this, i propose to make the Translator depending on a Package instance rather than its messages. We can then add new messages to the Package and the Translator will automatically have access to them.

Is there any reason why the Translator was design this way in the 1st place ?
