### PR TITLE
Add the shared Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+# Releasing this package: Actions -> Release -> Run workflow, pick the branch
+# (3.x) and type the version. Or from a terminal:
+#
+#     gh workflow run release.yml --ref 3.x -f version=3.0.2
+#
+# The shared workflow creates the tag itself, and only after every check has
+# passed. Do not tag by hand -- Packagist derives versions from tags, so a tag
+# is a published version the moment it exists.
+#
+# Release notes come from this package's own CHANGELOG.md. The version you type
+# must match the version at the top of the change log -- or, for a pre-release
+# such as 3.1.0-alpha1, its base version, so that alphas and betas do not each
+# need a change log section of their own.
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 3.0.2'
+        required: true
+        type: string
+
+jobs:
+  release:
+    uses: auraphp/bin/.github/workflows/release.yml@v1.0.0
+    permissions:
+      contents: write
+    with:
+      version: ${{ inputs.version }}


### PR DESCRIPTION
This package had no release workflow, so cutting a release meant tagging by hand — which is exactly what the shared workflow exists to prevent. Packagist derives versions from tags, so a tag is a published version the moment it exists, and checks that run *after* a tag push cannot un-publish anything. The shared workflow creates the tag last, from the exact commit that passed every check.

Adds `.github/workflows/release.yml`, calling `auraphp/bin/.github/workflows/release.yml@v1.0.0`. It is the same caller Aura.Filter uses, with no per-package tuning.

## Checked, not assumed

The shared workflow's pre-release test run defaults to **PHP 8.4**, but this package's CI matrix tops out at **8.2** — so the workflow would test on a PHP version this package has never been tested against. That was worth verifying rather than assuming, since it is the kind of gap that turns into a failed release.

- Ran the suite on PHP 8.4: **OK (29 tests, 40 assertions)**.
- `require.php` is `^5.6 || ^7.0 || ^8.0` — `^8.0` means `>=8.0 <9.0`, so 8.4 is admitted and `composer install` resolves.

No `php-version` pin is needed. Worth noting separately that CI not covering 8.3/8.4 is a gap in its own right, but that is outside this change.

## Releasing

Actions → Release → Run workflow, pick `3.x`, type the version. Or:

```
gh workflow run release.yml --ref 3.x -f version=3.0.2
```

The version typed must match the version at the top of `CHANGELOG.md` (currently `3.0.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lgup8xLZHLQmavt7JoEQ4C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgup8xLZHLQmavt7JoEQ4C)_