### PR TITLE
Test on every supported PHP version, through 8.5

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,12 +8,18 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    name: PHP ${{ matrix.php-version }}
+
+    runs-on: ${{ matrix.operating-system }}
 
     strategy:
+      # Every version reports for itself; one red job should not hide the rest.
+      fail-fast: false
       matrix:
         operating-system:
           - ubuntu-latest
+        # The whole range admitted by the php constraint in composer.json,
+        # ^5.6 || ^7.0 || ^8.0, up to the current release, 8.5.
         php-version:
           - '5.6'
           - '7.0'
@@ -24,16 +30,36 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
+          - '8.4'
+          - '8.5'
+        include:
+          # Composer 2.3 and later need PHP 7.2.5, so anything older stays on
+          # the 2.2 LTS line. Everything else tracks the current 2.x.
+          - php-version: '5.6'
+            composer-version: '2.2'
+          - php-version: '7.0'
+            composer-version: '2.2'
+          - php-version: '7.1'
+            composer-version: '2.2'
+          # One job measures coverage. The report is the same whichever version
+          # produces it, and collecting it everywhere only bought twelve
+          # uploads of it -- including from the PHPUnit versions that write no
+          # clover file at all, which failed the upload quietly.
+          - php-version: '8.4'
+            coverage: true
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
 
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: xdebug
-          tools: composer:2.2
+          extensions: intl
+          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
+          tools: composer:${{ matrix.composer-version || 'v2' }}
           ini-values: assert.exception=1, zend.assertions=1
 
       - name: Get composer cache directory
@@ -41,19 +67,42 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          # There is no committed lock file, and each PHP version resolves to a
+          # different PHPUnit, so the version is part of the key.
+          key: ${{ runner.os }}-php${{ matrix.php-version }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: ${{ runner.os }}-php${{ matrix.php-version }}-composer-
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: composer install --no-interaction --prefer-dist --no-progress
 
       - name: Run test suite
-        run: php -d xdebug.mode=coverage ./vendor/bin/phpunit --coverage-clover=coverage.xml
+        run: php -d xdebug.mode=coverage ./vendor/bin/phpunit --log-junit=junit.xml ${{ matrix.coverage && '--coverage-clover=coverage.xml' || '' }}
+
+      - name: Check the suite was not empty
+        # One config file drives PHPUnit 5.7 through 9.6 here. A version that
+        # read it and selected nothing would still exit 0, so the run is only
+        # green if it actually executed tests.
+        run: |
+          php -r '
+            $log = simplexml_load_file("junit.xml");
+            $tests = 0;
+            foreach ($log->testsuite as $suite) {
+                $tests += (int) $suite["tests"];
+            }
+            if ($tests < 1) {
+                fwrite(STDERR, "No tests were executed." . PHP_EOL);
+                exit(1);
+            }
+            echo $tests . " tests executed." . PHP_EOL;
+          '
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v2
+        if: ${{ matrix.coverage }}
+        uses: codecov/codecov-action@v5
         with:
+          files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /composer.lock
 /.phpunit.result.cache
 /.phpdoc
+/junit.xml
+/coverage.xml


### PR DESCRIPTION
CI on `3.x` is not merely missing PHP versions — it has not run a test in some time. Every job dies at "Prepare all required actions":

> This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`.

GitHub closed down the v1 cache service API and auto-fails any job that uses `actions/cache` v1/v2, so the whole matrix fails before `Setup PHP`. That is why #41's checks are red too, on a change that touches only `release.yml`.

## What changed

`.github/workflows/continuous-integration.yml` (plus two lines in `.gitignore` for the files CI writes).

- **Retired actions.** `actions/cache@v2` → `v4`, and, while the file was open, `actions/checkout@v1` → `v5` and `codecov/codecov-action@v2` → `v5` (v2 uploads through the retired bash uploader).
- **The full supported range.** `composer.json` admits `^5.6 || ^7.0 || ^8.0`; the matrix stopped at 8.2. It now runs 5.6, 7.0–7.4 and 8.0–8.5 — twelve versions, all green.
- **Composer split.** Composer 2.3 and later need PHP 7.2.5, so 5.6, 7.0 and 7.1 pin the 2.2 LTS line through a matrix `include`. Everything else now tracks current 2.x instead of the `composer:2.2` the whole matrix used to share.
- **Coverage from one job** instead of twelve, and an empty-suite guard — both explained below.

## Checked, not assumed

Nothing pins PHPUnit, so composer resolves a different one per PHP version. Before pushing, resolution was simulated for each of the twelve with a `platform.php` override:

| PHP | PHPUnit |
| --- | --- |
| 5.6 | 5.7.27 |
| 7.0 | 6.5.14 |
| 7.1 | 7.5.20 |
| 7.2 | 8.5.54 |
| 7.3 – 8.5 | 9.6.36 |

`yoast/phpunit-polyfills` needed no constraint change: `~1.0` resolves 1.1.5 on all twelve, and it is what lets one suite span that range — the tests already use its snake_case fixtures (`set_up()`), so the `setUp(): void` signature break across PHPUnit majors never arises. The suite was also run locally on 8.4 (OK, 29 tests, 40 assertions) before the first push.

## Two problems found while verifying, fixed here

**Coverage was failing silently on the older versions.** The first green run showed, in the PHP 5.6 job:

```
warning -- Some files were not found --- {"not_found_files": ["coverage.xml"]}
Error: No coverage reports found.
```

No clover file is written there, and `fail_ci_if_error: false` swallowed the upload error — visible only in the log. Coverage now comes from a single job (8.4), the only one that installs xdebug and the only one that uploads. The report is the same whichever version produces it; collecting it everywhere only bought twelve uploads of it, some of them broken. Confirmed on the current run: `Found 1 coverage files to report` → upload queued.

**A silently empty run would have passed.** One `phpunit.xml.dist` on the 9.3 schema drives PHPUnit 5.7 through 9.6. A version that read it and selected no tests would still exit 0. Each job now writes a JUnit log and fails if it records no tests, so green means tests actually ran; the step prints the count.

Also: `fail-fast` is off, so one red version no longer cancels the other eleven, and the composer cache key carries the PHP version, since each downloads a different PHPUnit.

## Result

All twelve jobs green: https://github.com/auraphp/Aura.Intl/actions/runs/34389256132

This also closes the gap #41 flagged in its own description — the shared release workflow's pre-release run defaults to PHP 8.4, which CI now covers. The two branches touch different files and do not conflict.

## Worth knowing, not changed here

On 8.4 and 8.5 the suite emits `Implicitly marking parameter $fallback as nullable is deprecated` from `Translator`, `TranslatorFactory` and one test. Harmless today, fatal in PHP 9 — and not fixable while 5.6 is supported, since `?Package` needs 7.1+. It is a decision for whenever the 5.6 floor moves, not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lsqqqef63W2xy6yHcZBRyh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lsqqqef63W2xy6yHcZBRyh)_