### PR TITLE
Add the 3.0.2 change log section for the Release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG
 
+<!--
+The Release workflow (Actions -> Release) publishes the version at the top of
+this file: the version you dispatch must match that heading, and the bullets
+below it become the GitHub release notes. Add the new section, drop any
+"(unreleased)" marker, and commit before running the workflow.
+-->
+
+## 3.0.2
+- No changes to the library itself; this release covers packaging and tooling only.
+- Continuous integration now runs the test suite on every PHP version the package
+  claims to support, 5.6 through 8.5.
+- Releases are cut by the shared Aura Release workflow: it runs the checks, tags
+  the commit that passed them, and publishes the notes from this change log.
+  Producer is no longer used to release this package.
+- Test coverage is reported to Codecov instead of Scrutinizer.
+- Migrated `phpunit.xml.dist` to the current schema, so recent PHPUnit versions
+  read it without deprecation warnings.
+
 ## 3.0.1
 - Moved from travis to github actions workflow.
 - Added yoast/phpunit-polyfills to support testing from 5.6 onwards.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Alternatively, [download a release][], or clone this repository, then map the
 
 ## Dependencies
 
-This package requires PHP 5.6 or later; it has been tested on PHP 5.6-8.2. We recommend using the latest available version of PHP as a matter of
+This package requires PHP 5.6 or later; it is tested on every version from 5.6
+to 8.5. We recommend using the latest available version of PHP as a matter of
 principle.
 
 Aura library packages may sometimes depend on external interfaces, but never on


### PR DESCRIPTION
The Release workflow publishes the version at the top of CHANGELOG.md and
uses the bullets under it as the release notes, refusing to run when the
dispatched version does not match that heading. The file still headed with
3.0.1, the version already tagged, so there was nothing releasable to
dispatch against.

Add a 3.0.2 section covering everything that landed since 3.0.1 -- all of it
packaging and tooling, as src/ is untouched -- and a comment at the top of
the file recording what the workflow expects of it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016zb6sF9S6yWzVZVvhVyX3C